### PR TITLE
Add formula display and file mode

### DIFF
--- a/src/logic.h
+++ b/src/logic.h
@@ -11,16 +11,20 @@ typedef struct {
     char vars[MAX_VARS][MAX_NAME]; /* variable names */
     int num_entries;               /* size of table = 1<<arity */
     unsigned char table[1<<MAX_VARS];
+    char *formula;                 /* textual formula, NULL if none */
 } Function;
 
 void logic_init(void);
 int add_function_table(const char *name, int arity, const char vars[][MAX_NAME],
-                       const unsigned char *table, int num_entries);
+                       const unsigned char *table, int num_entries,
+                       const char *formula);
 void list_functions(void);
 
 void print_varlist(const char *name);
 
 void print_table(const char *name);
+
+void print_formula(const char *name);
 
 void eval_and_print(const char *name, const int *values, int value_count);
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,14 +1,31 @@
-#include "logic.h"        
-#include "parser.tab.h"   
+#include "logic.h"
+#include "parser.tab.h"
 #include <stdio.h>
 
 extern int yyparse(void);
+extern FILE *yyin;
+extern int yylineno;
 
-int main(void)
+int from_file = 0;
+
+int main(int argc, char **argv)
 {
+    if (argc > 2) {
+        fprintf(stderr, "usage: %s [file]\n", argv[0]);
+        return 1;
+    }
+    if (argc == 2) {
+        yyin = fopen(argv[1], "r");
+        if (!yyin) { perror(argv[1]); return 1; }
+        from_file = 1;
+    }
+
     logic_init();
     puts("Logic");
     puts("");
-    yyparse();
+    if (yyparse() != 0 && from_file) {
+        fprintf(stderr, "error near line %d\n", yylineno);
+        return 1;
+    }
     return 0;
 }


### PR DESCRIPTION
## Summary
- store formula text when defining functions
- add `formula` command to show formulas or compute DNF from a table
- support running the interpreter on a file and print error line numbers

## Testing
- `make`
- `./logic_interpreter <<'EOF'
Define f = x or !z
formula f
Define h = { 1 0 1 1 }
formula h
EOF`
- `./logic_interpreter test.txt`

------
https://chatgpt.com/codex/tasks/task_e_6852b474b9ec832891d50c468c445dae